### PR TITLE
Adds regression tests for https://github.com/rtfeldman/elm-css/issues/564

### DIFF
--- a/tests/Styled.elm
+++ b/tests/Styled.elm
@@ -4,7 +4,7 @@ module Styled exposing (all)
 
 import Css exposing (..)
 import Html.Styled exposing (Html, a, button, div, header, img, nav, text, toUnstyled)
-import Html.Styled.Attributes exposing (css, src)
+import Html.Styled.Attributes exposing (class, css, src)
 import Test exposing (Test, describe)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
@@ -107,4 +107,37 @@ all =
                         , Selector.text "._20d887e{padding:16px;padding-left:24px;padding-right:24px;margin-left:50px;margin-right:auto;color:rgb(255,255,255);background-color:rgb(27,217,130);vertical-align:middle;}"
                         ]
             )
+        , bug564
+        ]
+
+
+bug564 : Test
+bug564 =
+    describe "Github Issue #564: https://github.com/rtfeldman/elm-css/issues/564"
+        [ Test.test "generated class is included when there's no custom class" <|
+            \_ ->
+                div
+                    [ css [ color (rgb 0 0 0) ]
+                    ]
+                    []
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.class "_5dc67897" ]
+        , Test.test "custom class is included when there's no generated class" <|
+            \_ ->
+                div [ class "some-custom-class" ]
+                    []
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.class "some-custom-class" ]
+        , Test.test "custom class is included as well as generated class" <|
+            \_ ->
+                div
+                    [ css [ color (rgb 0 0 0) ]
+                    , class "some-custom-class"
+                    ]
+                    []
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.classes [ "_5dc67897", "some-custom-class" ] ]
         ]


### PR DESCRIPTION
Adds regression tests for https://github.com/rtfeldman/elm-css/issues/564

Tests against SVG class behavior cannot be added, because elm-test doesn't support testing class names that are set with `attribute` rather than `property`.

See [Properties versus Attributes](https://github.com/elm/html/blob/master/properties-vs-attributes.md) and comment with example failing tests [here](https://github.com/rtfeldman/elm-css/issues/564#issuecomment-1010418152).

@Confidenceman02  are you open to adding some tests to https://github.com/rtfeldman/elm-css/pull/565?